### PR TITLE
Added linked in and events to news

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -25,6 +25,7 @@ publishDir = "docs"
   # Enable parts of social widget
   twitter = "RSE_Midlands"
   github = "RSE-Midlands"
+  linkedin = "groups/12657864"
 
 
 [menu]

--- a/content/docs/news.md
+++ b/content/docs/news.md
@@ -1,6 +1,6 @@
 ---
-title: Events
-description: Upcoming RSE Midlands events
+title: News
+description: News from the RSE midlands group
 date: 2022-01-24T14:00:00.000Z
 authorbox: false
 sidebar: false
@@ -8,17 +8,17 @@ pager: false
 weight: 3
 menu:
   main:
-    name: Events
+    name: News
 ---
 
 ##### Inaugural Meeting
+
+We are pleased to announce the first RSE Midlands meetup.
 
 When: **8th June 2022**
 
 Where: **The Writers' Suite, Edgbaston Park Hotel and Conference Centre, 53 Edgbaston Park Road, Edgbaston, Birmingham, B15 2RS, United Kingdom** ([map](https://goo.gl/maps/x6MygSQ8JwRsx4U9A))
 
 Save the date!
-
-More details are forthcoming.
 
 <!--more-->

--- a/content/posts/my-first-post.md
+++ b/content/posts/my-first-post.md
@@ -1,7 +1,7 @@
 ---
 title: "My First Post"
 date: 2022-03-18T11:21:24Z
-draft: false
+draft: true
 ---
 
 Here is my first post.

--- a/docs/404.html
+++ b/docs/404.html
@@ -29,7 +29,7 @@
 					<img class="logo__img" src="/images/logo_400x400.jpg">
 				</div><div class="logo__item logo__text">
 					<div class="logo__title">RSE-Midlands</div>
-					<div class="logo__tagline">A community of Research Software Engineers (RSEs) within the Midlands in England.</div>
+					<div class="logo__tagline">A community of Research Software Engineers (RSEs) within the Midlands of England.</div>
 				</div>
 		</a>
 	</div>
@@ -75,13 +75,22 @@
 	<h4 class="widget-social__title widget__title">Social</h4>
 	<div class="widget-social__content widget__content">
 		<div class="widget-social__item widget__item">
-			<a class="widget-social__link widget__link btn" title="Twitter" rel="noopener noreferrer" href="https://twitter.com/RSE_Midlands" target="_blank">
+			<a class="widget-social__link widget__link btn" title="Twitter" rel="noopener noreferrer"
+				href="https://twitter.com/RSE_Midlands" target="_blank">
 				<svg class="widget-social__link-icon icon icon-twitter" width="24" height="24" viewBox="0 0 384 312"><path d="m384 36.9c-14.1 6.3-29.3 10.5-45.2 12.4 16.3-9.7 28.8-25.2 34.6-43.6-15.2 9-32.1 15.6-50 19.1-14.4-15.2-34.9-24.8-57.5-24.8-43.5 0-78.8 35.3-78.8 78.8 0 6.2.7 12.2 2 17.9-65.5-3.3-123.5-34.6-162.4-82.3-6.7 11.6-10.6 25.2-10.6 39.6 0 27.3 13.9 51.4 35 65.6-12.9-.4-25.1-4-35.7-9.9v1c0 38.2 27.2 70 63.2 77.2-6.6 1.8-13.6 2.8-20.8 2.8-5.1 0-10-.5-14.8-1.4 10 31.3 39.1 54.1 73.6 54.7-27 21.1-60.9 33.7-97.8 33.7-6.4 0-12.6-.4-18.8-1.1 34.9 22.4 76.3 35.4 120.8 35.4 144.9 0 224.1-120 224.1-224.1 0-3.4-.1-6.8-.2-10.2 15.4-11.1 28.7-25 39.3-40.8z"/></svg>
 				<span>Twitter</span>
 			</a>
 		</div>
 		<div class="widget-social__item widget__item">
-			<a class="widget-social__link widget__link btn" title="GitHub" rel="noopener noreferrer" href="https://github.com/RSE-Midlands" target="_blank">
+			<a class="widget-social__link widget__link btn" title="LinkedIn" rel="noopener noreferrer"
+				href="https://linkedin.com/groups/12657864" target="_blank">
+				<svg class="widget-social__link-icon icon icon-linkedin" width="24" height="24" viewBox="0 0 352 352"><path d="M0,40v272c0,21.9,18.1,40,40,40h272c21.9,0,40-18.1,40-40V40c0-21.9-18.1-40-40-40H40C18.1,0,0,18.1,0,40z M312,32 c4.6,0,8,3.4,8,8v272c0,4.6-3.4,8-8,8H40c-4.6,0-8-3.4-8-8V40c0-4.6,3.4-8,8-8H312z M59.5,87c0,15.2,12.3,27.5,27.5,27.5 c15.2,0,27.5-12.3,27.5-27.5c0-15.2-12.3-27.5-27.5-27.5C71.8,59.5,59.5,71.8,59.5,87z M187,157h-1v-21h-45v152h47v-75 c0-19.8,3.9-39,28.5-39c24.2,0,24.5,22.4,24.5,40v74h47v-83.5c0-40.9-8.7-72-56.5-72C208.5,132.5,193.3,145.1,187,157z M64,288h47.5 V136H64V288z"/></svg>
+				<span>LinkedIn</span>
+			</a>
+		</div>
+		<div class="widget-social__item widget__item">
+			<a class="widget-social__link widget__link btn" title="GitHub" rel="noopener noreferrer"
+				href="https://github.com/RSE-Midlands" target="_blank">
 				<svg class="widget-social__link-icon icon icon-github" width="24" height="24" viewBox="0 0 384 374"><path d="m192 0c-106.1 0-192 85.8-192 191.7 0 84.7 55 156.6 131.3 181.9 9.6 1.8 13.1-4.2 13.1-9.2 0-4.6-.2-16.6-.3-32.6-53.4 11.6-64.7-25.7-64.7-25.7-8.7-22.1-21.3-28-21.3-28-17.4-11.9 1.3-11.6 1.3-11.6 19.3 1.4 29.4 19.8 29.4 19.8 17.1 29.3 44.9 20.8 55.9 15.9 1.7-12.4 6.7-20.8 12.2-25.6-42.6-4.8-87.5-21.3-87.5-94.8 0-20.9 7.5-38 19.8-51.4-2-4.9-8.6-24.3 1.9-50.7 0 0 16.1-5.2 52.8 19.7 15.3-4.2 31.7-6.4 48.1-6.5 16.3.1 32.7 2.2 48.1 6.5 36.7-24.8 52.8-19.7 52.8-19.7 10.5 26.4 3.9 45.9 1.9 50.7 12.3 13.4 19.7 30.5 19.7 51.4 0 73.7-44.9 89.9-87.7 94.6 6.9 5.9 13 17.6 13 35.5 0 25.6-.2 46.3-.2 52.6 0 5.1 3.5 11.1 13.2 9.2 76.2-25.5 131.2-97.3 131.2-182 0-105.9-86-191.7-192-191.7z"/></svg>
 				<span>GitHub</span>
 			</a>

--- a/docs/categories/index.html
+++ b/docs/categories/index.html
@@ -30,7 +30,7 @@
 					<img class="logo__img" src="/images/logo_400x400.jpg">
 				</div><div class="logo__item logo__text">
 					<div class="logo__title">RSE-Midlands</div>
-					<div class="logo__tagline">A community of Research Software Engineers (RSEs) within the Midlands in England.</div>
+					<div class="logo__tagline">A community of Research Software Engineers (RSEs) within the Midlands of England.</div>
 				</div>
 		</a>
 	</div>
@@ -76,13 +76,22 @@
 	<h4 class="widget-social__title widget__title">Social</h4>
 	<div class="widget-social__content widget__content">
 		<div class="widget-social__item widget__item">
-			<a class="widget-social__link widget__link btn" title="Twitter" rel="noopener noreferrer" href="https://twitter.com/RSE_Midlands" target="_blank">
+			<a class="widget-social__link widget__link btn" title="Twitter" rel="noopener noreferrer"
+				href="https://twitter.com/RSE_Midlands" target="_blank">
 				<svg class="widget-social__link-icon icon icon-twitter" width="24" height="24" viewBox="0 0 384 312"><path d="m384 36.9c-14.1 6.3-29.3 10.5-45.2 12.4 16.3-9.7 28.8-25.2 34.6-43.6-15.2 9-32.1 15.6-50 19.1-14.4-15.2-34.9-24.8-57.5-24.8-43.5 0-78.8 35.3-78.8 78.8 0 6.2.7 12.2 2 17.9-65.5-3.3-123.5-34.6-162.4-82.3-6.7 11.6-10.6 25.2-10.6 39.6 0 27.3 13.9 51.4 35 65.6-12.9-.4-25.1-4-35.7-9.9v1c0 38.2 27.2 70 63.2 77.2-6.6 1.8-13.6 2.8-20.8 2.8-5.1 0-10-.5-14.8-1.4 10 31.3 39.1 54.1 73.6 54.7-27 21.1-60.9 33.7-97.8 33.7-6.4 0-12.6-.4-18.8-1.1 34.9 22.4 76.3 35.4 120.8 35.4 144.9 0 224.1-120 224.1-224.1 0-3.4-.1-6.8-.2-10.2 15.4-11.1 28.7-25 39.3-40.8z"/></svg>
 				<span>Twitter</span>
 			</a>
 		</div>
 		<div class="widget-social__item widget__item">
-			<a class="widget-social__link widget__link btn" title="GitHub" rel="noopener noreferrer" href="https://github.com/RSE-Midlands" target="_blank">
+			<a class="widget-social__link widget__link btn" title="LinkedIn" rel="noopener noreferrer"
+				href="https://linkedin.com/groups/12657864" target="_blank">
+				<svg class="widget-social__link-icon icon icon-linkedin" width="24" height="24" viewBox="0 0 352 352"><path d="M0,40v272c0,21.9,18.1,40,40,40h272c21.9,0,40-18.1,40-40V40c0-21.9-18.1-40-40-40H40C18.1,0,0,18.1,0,40z M312,32 c4.6,0,8,3.4,8,8v272c0,4.6-3.4,8-8,8H40c-4.6,0-8-3.4-8-8V40c0-4.6,3.4-8,8-8H312z M59.5,87c0,15.2,12.3,27.5,27.5,27.5 c15.2,0,27.5-12.3,27.5-27.5c0-15.2-12.3-27.5-27.5-27.5C71.8,59.5,59.5,71.8,59.5,87z M187,157h-1v-21h-45v152h47v-75 c0-19.8,3.9-39,28.5-39c24.2,0,24.5,22.4,24.5,40v74h47v-83.5c0-40.9-8.7-72-56.5-72C208.5,132.5,193.3,145.1,187,157z M64,288h47.5 V136H64V288z"/></svg>
+				<span>LinkedIn</span>
+			</a>
+		</div>
+		<div class="widget-social__item widget__item">
+			<a class="widget-social__link widget__link btn" title="GitHub" rel="noopener noreferrer"
+				href="https://github.com/RSE-Midlands" target="_blank">
 				<svg class="widget-social__link-icon icon icon-github" width="24" height="24" viewBox="0 0 384 374"><path d="m192 0c-106.1 0-192 85.8-192 191.7 0 84.7 55 156.6 131.3 181.9 9.6 1.8 13.1-4.2 13.1-9.2 0-4.6-.2-16.6-.3-32.6-53.4 11.6-64.7-25.7-64.7-25.7-8.7-22.1-21.3-28-21.3-28-17.4-11.9 1.3-11.6 1.3-11.6 19.3 1.4 29.4 19.8 29.4 19.8 17.1 29.3 44.9 20.8 55.9 15.9 1.7-12.4 6.7-20.8 12.2-25.6-42.6-4.8-87.5-21.3-87.5-94.8 0-20.9 7.5-38 19.8-51.4-2-4.9-8.6-24.3 1.9-50.7 0 0 16.1-5.2 52.8 19.7 15.3-4.2 31.7-6.4 48.1-6.5 16.3.1 32.7 2.2 48.1 6.5 36.7-24.8 52.8-19.7 52.8-19.7 10.5 26.4 3.9 45.9 1.9 50.7 12.3 13.4 19.7 30.5 19.7 51.4 0 73.7-44.9 89.9-87.7 94.6 6.9 5.9 13 17.6 13 35.5 0 25.6-.2 46.3-.2 52.6 0 5.1 3.5 11.1 13.2 9.2 76.2-25.5 131.2-97.3 131.2-182 0-105.9-86-191.7-192-191.7z"/></svg>
 				<span>GitHub</span>
 			</a>

--- a/docs/docs/about/index.html
+++ b/docs/docs/about/index.html
@@ -29,7 +29,7 @@
 					<img class="logo__img" src="/images/logo_400x400.jpg">
 				</div><div class="logo__item logo__text">
 					<div class="logo__title">RSE-Midlands</div>
-					<div class="logo__tagline">A community of Research Software Engineers (RSEs) within the Midlands in England.</div>
+					<div class="logo__tagline">A community of Research Software Engineers (RSEs) within the Midlands of England.</div>
 				</div>
 		</a>
 	</div>
@@ -68,8 +68,8 @@
 			
 		</header>
 		<div class="content post__content clearfix">
-			<p>We are a group who work in with and develop research software and are in the Midlands area of England.</p>
-<p>We are members of the <a href="https://society-rse.org/">Society of Research Software Engineering</a>. You may ask &lsquo;What is a Research Software Engineer?&rsquo;. You can find out more about the sorts of roles <a href="https://society-rse.org/about/">here</a>.</p>
+			<p>We are a group who use or develop research software and work in the Midlands area of England.</p>
+<p>We are members of the <a href="https://society-rse.org/">Society of Research Software Engineering (SocRSE)</a>. You may ask &lsquo;What is a Research Software Engineer (RSE)?&rsquo;. You can find out about a variety of RSE roles in through the <a href="https://society-rse.org/careers/case-studies/">SocRSE case studies</a>.</p>
 		</div>
 	</article>
 </main>

--- a/docs/docs/events/index.html
+++ b/docs/docs/events/index.html
@@ -29,7 +29,7 @@
 					<img class="logo__img" src="/images/logo_400x400.jpg">
 				</div><div class="logo__item logo__text">
 					<div class="logo__title">RSE-Midlands</div>
-					<div class="logo__tagline">A community of Research Software Engineers (RSEs) within the Midlands in England.</div>
+					<div class="logo__tagline">A community of Research Software Engineers (RSEs) within the Midlands of England.</div>
 				</div>
 		</a>
 	</div>
@@ -68,9 +68,9 @@
 			
 		</header>
 		<div class="content post__content clearfix">
-			<h5 id="inagrual-meeting">Inagrual Meeting</h5>
+			<h5 id="inaugural-meeting">Inaugural Meeting</h5>
 <p>When: <strong>8th June 2022</strong></p>
-<p>Where: <strong>The Writer Suite, Edgbaston Park Hotel and Conference Centre, 53 Edgbaston Park Road, Edgbaston, Birmingham, B15 2RS, United Kingdom</strong> (<a href="https://goo.gl/maps/x6MygSQ8JwRsx4U9A">map</a>)</p>
+<p>Where: <strong>The Writers&rsquo; Suite, Edgbaston Park Hotel and Conference Centre, 53 Edgbaston Park Road, Edgbaston, Birmingham, B15 2RS, United Kingdom</strong> (<a href="https://goo.gl/maps/x6MygSQ8JwRsx4U9A">map</a>)</p>
 <p>Save the date!</p>
 <p>More details are forthcoming.</p>
 		</div>

--- a/docs/docs/index.html
+++ b/docs/docs/index.html
@@ -30,7 +30,7 @@
 					<img class="logo__img" src="/images/logo_400x400.jpg">
 				</div><div class="logo__item logo__text">
 					<div class="logo__title">RSE-Midlands</div>
-					<div class="logo__tagline">A community of Research Software Engineers (RSEs) within the Midlands in England.</div>
+					<div class="logo__tagline">A community of Research Software Engineers (RSEs) within the Midlands of England.</div>
 				</div>
 		</a>
 	</div>
@@ -76,8 +76,8 @@
 		
 	</header>
 	<div class="content list__excerpt post__content clearfix">
-		<p>We are a group who work in with and develop research software and are in the Midlands area of England.</p>
-<p>We are members of the <a href="https://society-rse.org/">Society of Research Software Engineering</a>. You may ask &lsquo;What is a Research Software Engineer?&rsquo;. You can find out more about the sorts of roles <a href="https://society-rse.org/about/">here</a>.</p>
+		<p>We are a group who use or develop research software and work in the Midlands area of England.</p>
+<p>We are members of the <a href="https://society-rse.org/">Society of Research Software Engineering (SocRSE)</a>. You may ask &lsquo;What is a Research Software Engineer (RSE)?&rsquo;. You can find out about a variety of RSE roles in through the <a href="https://society-rse.org/careers/case-studies/">SocRSE case studies</a>.</p>
 	</div>
 </article><article class="list__item post">
 	
@@ -90,9 +90,9 @@
 		
 	</header>
 	<div class="content list__excerpt post__content clearfix">
-		<h5 id="inagrual-meeting">Inagrual Meeting</h5>
+		<h5 id="inaugural-meeting">Inaugural Meeting</h5>
 <p>When: <strong>8th June 2022</strong></p>
-<p>Where: <strong>The Writer Suite, Edgbaston Park Hotel and Conference Centre, 53 Edgbaston Park Road, Edgbaston, Birmingham, B15 2RS, United Kingdom</strong> (<a href="https://goo.gl/maps/x6MygSQ8JwRsx4U9A">map</a>)</p>
+<p>Where: <strong>The Writers&rsquo; Suite, Edgbaston Park Hotel and Conference Centre, 53 Edgbaston Park Road, Edgbaston, Birmingham, B15 2RS, United Kingdom</strong> (<a href="https://goo.gl/maps/x6MygSQ8JwRsx4U9A">map</a>)</p>
 <p>Save the date!</p>
 <p>More details are forthcoming.</p>
 	</div>
@@ -107,13 +107,22 @@
 	<h4 class="widget-social__title widget__title">Social</h4>
 	<div class="widget-social__content widget__content">
 		<div class="widget-social__item widget__item">
-			<a class="widget-social__link widget__link btn" title="Twitter" rel="noopener noreferrer" href="https://twitter.com/RSE_Midlands" target="_blank">
+			<a class="widget-social__link widget__link btn" title="Twitter" rel="noopener noreferrer"
+				href="https://twitter.com/RSE_Midlands" target="_blank">
 				<svg class="widget-social__link-icon icon icon-twitter" width="24" height="24" viewBox="0 0 384 312"><path d="m384 36.9c-14.1 6.3-29.3 10.5-45.2 12.4 16.3-9.7 28.8-25.2 34.6-43.6-15.2 9-32.1 15.6-50 19.1-14.4-15.2-34.9-24.8-57.5-24.8-43.5 0-78.8 35.3-78.8 78.8 0 6.2.7 12.2 2 17.9-65.5-3.3-123.5-34.6-162.4-82.3-6.7 11.6-10.6 25.2-10.6 39.6 0 27.3 13.9 51.4 35 65.6-12.9-.4-25.1-4-35.7-9.9v1c0 38.2 27.2 70 63.2 77.2-6.6 1.8-13.6 2.8-20.8 2.8-5.1 0-10-.5-14.8-1.4 10 31.3 39.1 54.1 73.6 54.7-27 21.1-60.9 33.7-97.8 33.7-6.4 0-12.6-.4-18.8-1.1 34.9 22.4 76.3 35.4 120.8 35.4 144.9 0 224.1-120 224.1-224.1 0-3.4-.1-6.8-.2-10.2 15.4-11.1 28.7-25 39.3-40.8z"/></svg>
 				<span>Twitter</span>
 			</a>
 		</div>
 		<div class="widget-social__item widget__item">
-			<a class="widget-social__link widget__link btn" title="GitHub" rel="noopener noreferrer" href="https://github.com/RSE-Midlands" target="_blank">
+			<a class="widget-social__link widget__link btn" title="LinkedIn" rel="noopener noreferrer"
+				href="https://linkedin.com/groups/12657864" target="_blank">
+				<svg class="widget-social__link-icon icon icon-linkedin" width="24" height="24" viewBox="0 0 352 352"><path d="M0,40v272c0,21.9,18.1,40,40,40h272c21.9,0,40-18.1,40-40V40c0-21.9-18.1-40-40-40H40C18.1,0,0,18.1,0,40z M312,32 c4.6,0,8,3.4,8,8v272c0,4.6-3.4,8-8,8H40c-4.6,0-8-3.4-8-8V40c0-4.6,3.4-8,8-8H312z M59.5,87c0,15.2,12.3,27.5,27.5,27.5 c15.2,0,27.5-12.3,27.5-27.5c0-15.2-12.3-27.5-27.5-27.5C71.8,59.5,59.5,71.8,59.5,87z M187,157h-1v-21h-45v152h47v-75 c0-19.8,3.9-39,28.5-39c24.2,0,24.5,22.4,24.5,40v74h47v-83.5c0-40.9-8.7-72-56.5-72C208.5,132.5,193.3,145.1,187,157z M64,288h47.5 V136H64V288z"/></svg>
+				<span>LinkedIn</span>
+			</a>
+		</div>
+		<div class="widget-social__item widget__item">
+			<a class="widget-social__link widget__link btn" title="GitHub" rel="noopener noreferrer"
+				href="https://github.com/RSE-Midlands" target="_blank">
 				<svg class="widget-social__link-icon icon icon-github" width="24" height="24" viewBox="0 0 384 374"><path d="m192 0c-106.1 0-192 85.8-192 191.7 0 84.7 55 156.6 131.3 181.9 9.6 1.8 13.1-4.2 13.1-9.2 0-4.6-.2-16.6-.3-32.6-53.4 11.6-64.7-25.7-64.7-25.7-8.7-22.1-21.3-28-21.3-28-17.4-11.9 1.3-11.6 1.3-11.6 19.3 1.4 29.4 19.8 29.4 19.8 17.1 29.3 44.9 20.8 55.9 15.9 1.7-12.4 6.7-20.8 12.2-25.6-42.6-4.8-87.5-21.3-87.5-94.8 0-20.9 7.5-38 19.8-51.4-2-4.9-8.6-24.3 1.9-50.7 0 0 16.1-5.2 52.8 19.7 15.3-4.2 31.7-6.4 48.1-6.5 16.3.1 32.7 2.2 48.1 6.5 36.7-24.8 52.8-19.7 52.8-19.7 10.5 26.4 3.9 45.9 1.9 50.7 12.3 13.4 19.7 30.5 19.7 51.4 0 73.7-44.9 89.9-87.7 94.6 6.9 5.9 13 17.6 13 35.5 0 25.6-.2 46.3-.2 52.6 0 5.1 3.5 11.1 13.2 9.2 76.2-25.5 131.2-97.3 131.2-182 0-105.9-86-191.7-192-191.7z"/></svg>
 				<span>GitHub</span>
 			</a>

--- a/docs/docs/index.xml
+++ b/docs/docs/index.xml
@@ -13,8 +13,8 @@
       <pubDate>Mon, 24 Jan 2022 14:00:00 +0000</pubDate>
       
       <guid>http://rse-midlands.github.io/docs/about/</guid>
-      <description>&lt;p&gt;We are a group who work in with and develop research software and are in the Midlands area of England.&lt;/p&gt;
-&lt;p&gt;We are members of the &lt;a href=&#34;https://society-rse.org/&#34;&gt;Society of Research Software Engineering&lt;/a&gt;. You may ask &amp;lsquo;What is a Research Software Engineer?&amp;rsquo;. You can find out more about the sorts of roles &lt;a href=&#34;https://society-rse.org/about/&#34;&gt;here&lt;/a&gt;.&lt;/p&gt;</description>
+      <description>&lt;p&gt;We are a group who use or develop research software and work in the Midlands area of England.&lt;/p&gt;
+&lt;p&gt;We are members of the &lt;a href=&#34;https://society-rse.org/&#34;&gt;Society of Research Software Engineering (SocRSE)&lt;/a&gt;. You may ask &amp;lsquo;What is a Research Software Engineer (RSE)?&amp;rsquo;. You can find out about a variety of RSE roles in through the &lt;a href=&#34;https://society-rse.org/careers/case-studies/&#34;&gt;SocRSE case studies&lt;/a&gt;.&lt;/p&gt;</description>
     </item>
     
     <item>
@@ -23,9 +23,9 @@
       <pubDate>Mon, 24 Jan 2022 14:00:00 +0000</pubDate>
       
       <guid>http://rse-midlands.github.io/docs/events/</guid>
-      <description>&lt;h5 id=&#34;inagrual-meeting&#34;&gt;Inagrual Meeting&lt;/h5&gt;
+      <description>&lt;h5 id=&#34;inaugural-meeting&#34;&gt;Inaugural Meeting&lt;/h5&gt;
 &lt;p&gt;When: &lt;strong&gt;8th June 2022&lt;/strong&gt;&lt;/p&gt;
-&lt;p&gt;Where: &lt;strong&gt;The Writer Suite, Edgbaston Park Hotel and Conference Centre, 53 Edgbaston Park Road, Edgbaston, Birmingham, B15 2RS, United Kingdom&lt;/strong&gt; (&lt;a href=&#34;https://goo.gl/maps/x6MygSQ8JwRsx4U9A&#34;&gt;map&lt;/a&gt;)&lt;/p&gt;
+&lt;p&gt;Where: &lt;strong&gt;The Writers&amp;rsquo; Suite, Edgbaston Park Hotel and Conference Centre, 53 Edgbaston Park Road, Edgbaston, Birmingham, B15 2RS, United Kingdom&lt;/strong&gt; (&lt;a href=&#34;https://goo.gl/maps/x6MygSQ8JwRsx4U9A&#34;&gt;map&lt;/a&gt;)&lt;/p&gt;
 &lt;p&gt;Save the date!&lt;/p&gt;
 &lt;p&gt;More details are forthcoming.&lt;/p&gt;</description>
     </item>

--- a/docs/index.html
+++ b/docs/index.html
@@ -31,7 +31,7 @@
 					<img class="logo__img" src="/images/logo_400x400.jpg">
 				</div><div class="logo__item logo__text">
 					<div class="logo__title">RSE-Midlands</div>
-					<div class="logo__tagline">A community of Research Software Engineers (RSEs) within the Midlands in England.</div>
+					<div class="logo__tagline">A community of Research Software Engineers (RSEs) within the Midlands of England.</div>
 				</div>
 		</a>
 	</div>
@@ -75,8 +75,8 @@
 		
 	</header>
 	<div class="content list__excerpt post__content clearfix">
-		<p>We are a group who work in with and develop research software and are in the Midlands area of England.</p>
-<p>We are members of the <a href="https://society-rse.org/">Society of Research Software Engineering</a>. You may ask &lsquo;What is a Research Software Engineer?&rsquo;. You can find out more about the sorts of roles <a href="https://society-rse.org/about/">here</a>.</p>
+		<p>We are a group who use or develop research software and work in the Midlands area of England.</p>
+<p>We are members of the <a href="https://society-rse.org/">Society of Research Software Engineering (SocRSE)</a>. You may ask &lsquo;What is a Research Software Engineer (RSE)?&rsquo;. You can find out about a variety of RSE roles in through the <a href="https://society-rse.org/careers/case-studies/">SocRSE case studies</a>.</p>
 	</div>
 </article><article class="list__item post">
 	
@@ -89,9 +89,9 @@
 		
 	</header>
 	<div class="content list__excerpt post__content clearfix">
-		<h5 id="inagrual-meeting">Inagrual Meeting</h5>
+		<h5 id="inaugural-meeting">Inaugural Meeting</h5>
 <p>When: <strong>8th June 2022</strong></p>
-<p>Where: <strong>The Writer Suite, Edgbaston Park Hotel and Conference Centre, 53 Edgbaston Park Road, Edgbaston, Birmingham, B15 2RS, United Kingdom</strong> (<a href="https://goo.gl/maps/x6MygSQ8JwRsx4U9A">map</a>)</p>
+<p>Where: <strong>The Writers&rsquo; Suite, Edgbaston Park Hotel and Conference Centre, 53 Edgbaston Park Road, Edgbaston, Birmingham, B15 2RS, United Kingdom</strong> (<a href="https://goo.gl/maps/x6MygSQ8JwRsx4U9A">map</a>)</p>
 <p>Save the date!</p>
 <p>More details are forthcoming.</p>
 	</div>
@@ -105,13 +105,22 @@
 	<h4 class="widget-social__title widget__title">Social</h4>
 	<div class="widget-social__content widget__content">
 		<div class="widget-social__item widget__item">
-			<a class="widget-social__link widget__link btn" title="Twitter" rel="noopener noreferrer" href="https://twitter.com/RSE_Midlands" target="_blank">
+			<a class="widget-social__link widget__link btn" title="Twitter" rel="noopener noreferrer"
+				href="https://twitter.com/RSE_Midlands" target="_blank">
 				<svg class="widget-social__link-icon icon icon-twitter" width="24" height="24" viewBox="0 0 384 312"><path d="m384 36.9c-14.1 6.3-29.3 10.5-45.2 12.4 16.3-9.7 28.8-25.2 34.6-43.6-15.2 9-32.1 15.6-50 19.1-14.4-15.2-34.9-24.8-57.5-24.8-43.5 0-78.8 35.3-78.8 78.8 0 6.2.7 12.2 2 17.9-65.5-3.3-123.5-34.6-162.4-82.3-6.7 11.6-10.6 25.2-10.6 39.6 0 27.3 13.9 51.4 35 65.6-12.9-.4-25.1-4-35.7-9.9v1c0 38.2 27.2 70 63.2 77.2-6.6 1.8-13.6 2.8-20.8 2.8-5.1 0-10-.5-14.8-1.4 10 31.3 39.1 54.1 73.6 54.7-27 21.1-60.9 33.7-97.8 33.7-6.4 0-12.6-.4-18.8-1.1 34.9 22.4 76.3 35.4 120.8 35.4 144.9 0 224.1-120 224.1-224.1 0-3.4-.1-6.8-.2-10.2 15.4-11.1 28.7-25 39.3-40.8z"/></svg>
 				<span>Twitter</span>
 			</a>
 		</div>
 		<div class="widget-social__item widget__item">
-			<a class="widget-social__link widget__link btn" title="GitHub" rel="noopener noreferrer" href="https://github.com/RSE-Midlands" target="_blank">
+			<a class="widget-social__link widget__link btn" title="LinkedIn" rel="noopener noreferrer"
+				href="https://linkedin.com/groups/12657864" target="_blank">
+				<svg class="widget-social__link-icon icon icon-linkedin" width="24" height="24" viewBox="0 0 352 352"><path d="M0,40v272c0,21.9,18.1,40,40,40h272c21.9,0,40-18.1,40-40V40c0-21.9-18.1-40-40-40H40C18.1,0,0,18.1,0,40z M312,32 c4.6,0,8,3.4,8,8v272c0,4.6-3.4,8-8,8H40c-4.6,0-8-3.4-8-8V40c0-4.6,3.4-8,8-8H312z M59.5,87c0,15.2,12.3,27.5,27.5,27.5 c15.2,0,27.5-12.3,27.5-27.5c0-15.2-12.3-27.5-27.5-27.5C71.8,59.5,59.5,71.8,59.5,87z M187,157h-1v-21h-45v152h47v-75 c0-19.8,3.9-39,28.5-39c24.2,0,24.5,22.4,24.5,40v74h47v-83.5c0-40.9-8.7-72-56.5-72C208.5,132.5,193.3,145.1,187,157z M64,288h47.5 V136H64V288z"/></svg>
+				<span>LinkedIn</span>
+			</a>
+		</div>
+		<div class="widget-social__item widget__item">
+			<a class="widget-social__link widget__link btn" title="GitHub" rel="noopener noreferrer"
+				href="https://github.com/RSE-Midlands" target="_blank">
 				<svg class="widget-social__link-icon icon icon-github" width="24" height="24" viewBox="0 0 384 374"><path d="m192 0c-106.1 0-192 85.8-192 191.7 0 84.7 55 156.6 131.3 181.9 9.6 1.8 13.1-4.2 13.1-9.2 0-4.6-.2-16.6-.3-32.6-53.4 11.6-64.7-25.7-64.7-25.7-8.7-22.1-21.3-28-21.3-28-17.4-11.9 1.3-11.6 1.3-11.6 19.3 1.4 29.4 19.8 29.4 19.8 17.1 29.3 44.9 20.8 55.9 15.9 1.7-12.4 6.7-20.8 12.2-25.6-42.6-4.8-87.5-21.3-87.5-94.8 0-20.9 7.5-38 19.8-51.4-2-4.9-8.6-24.3 1.9-50.7 0 0 16.1-5.2 52.8 19.7 15.3-4.2 31.7-6.4 48.1-6.5 16.3.1 32.7 2.2 48.1 6.5 36.7-24.8 52.8-19.7 52.8-19.7 10.5 26.4 3.9 45.9 1.9 50.7 12.3 13.4 19.7 30.5 19.7 51.4 0 73.7-44.9 89.9-87.7 94.6 6.9 5.9 13 17.6 13 35.5 0 25.6-.2 46.3-.2 52.6 0 5.1 3.5 11.1 13.2 9.2 76.2-25.5 131.2-97.3 131.2-182 0-105.9-86-191.7-192-191.7z"/></svg>
 				<span>GitHub</span>
 			</a>

--- a/docs/index.xml
+++ b/docs/index.xml
@@ -13,8 +13,8 @@
       <pubDate>Mon, 24 Jan 2022 14:00:00 +0000</pubDate>
       
       <guid>http://rse-midlands.github.io/docs/about/</guid>
-      <description>&lt;p&gt;We are a group who work in with and develop research software and are in the Midlands area of England.&lt;/p&gt;
-&lt;p&gt;We are members of the &lt;a href=&#34;https://society-rse.org/&#34;&gt;Society of Research Software Engineering&lt;/a&gt;. You may ask &amp;lsquo;What is a Research Software Engineer?&amp;rsquo;. You can find out more about the sorts of roles &lt;a href=&#34;https://society-rse.org/about/&#34;&gt;here&lt;/a&gt;.&lt;/p&gt;</description>
+      <description>&lt;p&gt;We are a group who use or develop research software and work in the Midlands area of England.&lt;/p&gt;
+&lt;p&gt;We are members of the &lt;a href=&#34;https://society-rse.org/&#34;&gt;Society of Research Software Engineering (SocRSE)&lt;/a&gt;. You may ask &amp;lsquo;What is a Research Software Engineer (RSE)?&amp;rsquo;. You can find out about a variety of RSE roles in through the &lt;a href=&#34;https://society-rse.org/careers/case-studies/&#34;&gt;SocRSE case studies&lt;/a&gt;.&lt;/p&gt;</description>
     </item>
     
     <item>
@@ -23,9 +23,9 @@
       <pubDate>Mon, 24 Jan 2022 14:00:00 +0000</pubDate>
       
       <guid>http://rse-midlands.github.io/docs/events/</guid>
-      <description>&lt;h5 id=&#34;inagrual-meeting&#34;&gt;Inagrual Meeting&lt;/h5&gt;
+      <description>&lt;h5 id=&#34;inaugural-meeting&#34;&gt;Inaugural Meeting&lt;/h5&gt;
 &lt;p&gt;When: &lt;strong&gt;8th June 2022&lt;/strong&gt;&lt;/p&gt;
-&lt;p&gt;Where: &lt;strong&gt;The Writer Suite, Edgbaston Park Hotel and Conference Centre, 53 Edgbaston Park Road, Edgbaston, Birmingham, B15 2RS, United Kingdom&lt;/strong&gt; (&lt;a href=&#34;https://goo.gl/maps/x6MygSQ8JwRsx4U9A&#34;&gt;map&lt;/a&gt;)&lt;/p&gt;
+&lt;p&gt;Where: &lt;strong&gt;The Writers&amp;rsquo; Suite, Edgbaston Park Hotel and Conference Centre, 53 Edgbaston Park Road, Edgbaston, Birmingham, B15 2RS, United Kingdom&lt;/strong&gt; (&lt;a href=&#34;https://goo.gl/maps/x6MygSQ8JwRsx4U9A&#34;&gt;map&lt;/a&gt;)&lt;/p&gt;
 &lt;p&gt;Save the date!&lt;/p&gt;
 &lt;p&gt;More details are forthcoming.&lt;/p&gt;</description>
     </item>

--- a/docs/posts/index.html
+++ b/docs/posts/index.html
@@ -30,7 +30,7 @@
 					<img class="logo__img" src="/images/logo_400x400.jpg">
 				</div><div class="logo__item logo__text">
 					<div class="logo__title">RSE-Midlands</div>
-					<div class="logo__tagline">A community of Research Software Engineers (RSEs) within the Midlands in England.</div>
+					<div class="logo__tagline">A community of Research Software Engineers (RSEs) within the Midlands of England.</div>
 				</div>
 		</a>
 	</div>
@@ -89,13 +89,22 @@
 	<h4 class="widget-social__title widget__title">Social</h4>
 	<div class="widget-social__content widget__content">
 		<div class="widget-social__item widget__item">
-			<a class="widget-social__link widget__link btn" title="Twitter" rel="noopener noreferrer" href="https://twitter.com/RSE_Midlands" target="_blank">
+			<a class="widget-social__link widget__link btn" title="Twitter" rel="noopener noreferrer"
+				href="https://twitter.com/RSE_Midlands" target="_blank">
 				<svg class="widget-social__link-icon icon icon-twitter" width="24" height="24" viewBox="0 0 384 312"><path d="m384 36.9c-14.1 6.3-29.3 10.5-45.2 12.4 16.3-9.7 28.8-25.2 34.6-43.6-15.2 9-32.1 15.6-50 19.1-14.4-15.2-34.9-24.8-57.5-24.8-43.5 0-78.8 35.3-78.8 78.8 0 6.2.7 12.2 2 17.9-65.5-3.3-123.5-34.6-162.4-82.3-6.7 11.6-10.6 25.2-10.6 39.6 0 27.3 13.9 51.4 35 65.6-12.9-.4-25.1-4-35.7-9.9v1c0 38.2 27.2 70 63.2 77.2-6.6 1.8-13.6 2.8-20.8 2.8-5.1 0-10-.5-14.8-1.4 10 31.3 39.1 54.1 73.6 54.7-27 21.1-60.9 33.7-97.8 33.7-6.4 0-12.6-.4-18.8-1.1 34.9 22.4 76.3 35.4 120.8 35.4 144.9 0 224.1-120 224.1-224.1 0-3.4-.1-6.8-.2-10.2 15.4-11.1 28.7-25 39.3-40.8z"/></svg>
 				<span>Twitter</span>
 			</a>
 		</div>
 		<div class="widget-social__item widget__item">
-			<a class="widget-social__link widget__link btn" title="GitHub" rel="noopener noreferrer" href="https://github.com/RSE-Midlands" target="_blank">
+			<a class="widget-social__link widget__link btn" title="LinkedIn" rel="noopener noreferrer"
+				href="https://linkedin.com/groups/12657864" target="_blank">
+				<svg class="widget-social__link-icon icon icon-linkedin" width="24" height="24" viewBox="0 0 352 352"><path d="M0,40v272c0,21.9,18.1,40,40,40h272c21.9,0,40-18.1,40-40V40c0-21.9-18.1-40-40-40H40C18.1,0,0,18.1,0,40z M312,32 c4.6,0,8,3.4,8,8v272c0,4.6-3.4,8-8,8H40c-4.6,0-8-3.4-8-8V40c0-4.6,3.4-8,8-8H312z M59.5,87c0,15.2,12.3,27.5,27.5,27.5 c15.2,0,27.5-12.3,27.5-27.5c0-15.2-12.3-27.5-27.5-27.5C71.8,59.5,59.5,71.8,59.5,87z M187,157h-1v-21h-45v152h47v-75 c0-19.8,3.9-39,28.5-39c24.2,0,24.5,22.4,24.5,40v74h47v-83.5c0-40.9-8.7-72-56.5-72C208.5,132.5,193.3,145.1,187,157z M64,288h47.5 V136H64V288z"/></svg>
+				<span>LinkedIn</span>
+			</a>
+		</div>
+		<div class="widget-social__item widget__item">
+			<a class="widget-social__link widget__link btn" title="GitHub" rel="noopener noreferrer"
+				href="https://github.com/RSE-Midlands" target="_blank">
 				<svg class="widget-social__link-icon icon icon-github" width="24" height="24" viewBox="0 0 384 374"><path d="m192 0c-106.1 0-192 85.8-192 191.7 0 84.7 55 156.6 131.3 181.9 9.6 1.8 13.1-4.2 13.1-9.2 0-4.6-.2-16.6-.3-32.6-53.4 11.6-64.7-25.7-64.7-25.7-8.7-22.1-21.3-28-21.3-28-17.4-11.9 1.3-11.6 1.3-11.6 19.3 1.4 29.4 19.8 29.4 19.8 17.1 29.3 44.9 20.8 55.9 15.9 1.7-12.4 6.7-20.8 12.2-25.6-42.6-4.8-87.5-21.3-87.5-94.8 0-20.9 7.5-38 19.8-51.4-2-4.9-8.6-24.3 1.9-50.7 0 0 16.1-5.2 52.8 19.7 15.3-4.2 31.7-6.4 48.1-6.5 16.3.1 32.7 2.2 48.1 6.5 36.7-24.8 52.8-19.7 52.8-19.7 10.5 26.4 3.9 45.9 1.9 50.7 12.3 13.4 19.7 30.5 19.7 51.4 0 73.7-44.9 89.9-87.7 94.6 6.9 5.9 13 17.6 13 35.5 0 25.6-.2 46.3-.2 52.6 0 5.1 3.5 11.1 13.2 9.2 76.2-25.5 131.2-97.3 131.2-182 0-105.9-86-191.7-192-191.7z"/></svg>
 				<span>GitHub</span>
 			</a>

--- a/docs/posts/my-first-post/index.html
+++ b/docs/posts/my-first-post/index.html
@@ -29,7 +29,7 @@
 					<img class="logo__img" src="/images/logo_400x400.jpg">
 				</div><div class="logo__item logo__text">
 					<div class="logo__title">RSE-Midlands</div>
-					<div class="logo__tagline">A community of Research Software Engineers (RSEs) within the Midlands in England.</div>
+					<div class="logo__tagline">A community of Research Software Engineers (RSEs) within the Midlands of England.</div>
 				</div>
 		</a>
 	</div>
@@ -83,13 +83,22 @@
 	<h4 class="widget-social__title widget__title">Social</h4>
 	<div class="widget-social__content widget__content">
 		<div class="widget-social__item widget__item">
-			<a class="widget-social__link widget__link btn" title="Twitter" rel="noopener noreferrer" href="https://twitter.com/RSE_Midlands" target="_blank">
+			<a class="widget-social__link widget__link btn" title="Twitter" rel="noopener noreferrer"
+				href="https://twitter.com/RSE_Midlands" target="_blank">
 				<svg class="widget-social__link-icon icon icon-twitter" width="24" height="24" viewBox="0 0 384 312"><path d="m384 36.9c-14.1 6.3-29.3 10.5-45.2 12.4 16.3-9.7 28.8-25.2 34.6-43.6-15.2 9-32.1 15.6-50 19.1-14.4-15.2-34.9-24.8-57.5-24.8-43.5 0-78.8 35.3-78.8 78.8 0 6.2.7 12.2 2 17.9-65.5-3.3-123.5-34.6-162.4-82.3-6.7 11.6-10.6 25.2-10.6 39.6 0 27.3 13.9 51.4 35 65.6-12.9-.4-25.1-4-35.7-9.9v1c0 38.2 27.2 70 63.2 77.2-6.6 1.8-13.6 2.8-20.8 2.8-5.1 0-10-.5-14.8-1.4 10 31.3 39.1 54.1 73.6 54.7-27 21.1-60.9 33.7-97.8 33.7-6.4 0-12.6-.4-18.8-1.1 34.9 22.4 76.3 35.4 120.8 35.4 144.9 0 224.1-120 224.1-224.1 0-3.4-.1-6.8-.2-10.2 15.4-11.1 28.7-25 39.3-40.8z"/></svg>
 				<span>Twitter</span>
 			</a>
 		</div>
 		<div class="widget-social__item widget__item">
-			<a class="widget-social__link widget__link btn" title="GitHub" rel="noopener noreferrer" href="https://github.com/RSE-Midlands" target="_blank">
+			<a class="widget-social__link widget__link btn" title="LinkedIn" rel="noopener noreferrer"
+				href="https://linkedin.com/groups/12657864" target="_blank">
+				<svg class="widget-social__link-icon icon icon-linkedin" width="24" height="24" viewBox="0 0 352 352"><path d="M0,40v272c0,21.9,18.1,40,40,40h272c21.9,0,40-18.1,40-40V40c0-21.9-18.1-40-40-40H40C18.1,0,0,18.1,0,40z M312,32 c4.6,0,8,3.4,8,8v272c0,4.6-3.4,8-8,8H40c-4.6,0-8-3.4-8-8V40c0-4.6,3.4-8,8-8H312z M59.5,87c0,15.2,12.3,27.5,27.5,27.5 c15.2,0,27.5-12.3,27.5-27.5c0-15.2-12.3-27.5-27.5-27.5C71.8,59.5,59.5,71.8,59.5,87z M187,157h-1v-21h-45v152h47v-75 c0-19.8,3.9-39,28.5-39c24.2,0,24.5,22.4,24.5,40v74h47v-83.5c0-40.9-8.7-72-56.5-72C208.5,132.5,193.3,145.1,187,157z M64,288h47.5 V136H64V288z"/></svg>
+				<span>LinkedIn</span>
+			</a>
+		</div>
+		<div class="widget-social__item widget__item">
+			<a class="widget-social__link widget__link btn" title="GitHub" rel="noopener noreferrer"
+				href="https://github.com/RSE-Midlands" target="_blank">
 				<svg class="widget-social__link-icon icon icon-github" width="24" height="24" viewBox="0 0 384 374"><path d="m192 0c-106.1 0-192 85.8-192 191.7 0 84.7 55 156.6 131.3 181.9 9.6 1.8 13.1-4.2 13.1-9.2 0-4.6-.2-16.6-.3-32.6-53.4 11.6-64.7-25.7-64.7-25.7-8.7-22.1-21.3-28-21.3-28-17.4-11.9 1.3-11.6 1.3-11.6 19.3 1.4 29.4 19.8 29.4 19.8 17.1 29.3 44.9 20.8 55.9 15.9 1.7-12.4 6.7-20.8 12.2-25.6-42.6-4.8-87.5-21.3-87.5-94.8 0-20.9 7.5-38 19.8-51.4-2-4.9-8.6-24.3 1.9-50.7 0 0 16.1-5.2 52.8 19.7 15.3-4.2 31.7-6.4 48.1-6.5 16.3.1 32.7 2.2 48.1 6.5 36.7-24.8 52.8-19.7 52.8-19.7 10.5 26.4 3.9 45.9 1.9 50.7 12.3 13.4 19.7 30.5 19.7 51.4 0 73.7-44.9 89.9-87.7 94.6 6.9 5.9 13 17.6 13 35.5 0 25.6-.2 46.3-.2 52.6 0 5.1 3.5 11.1 13.2 9.2 76.2-25.5 131.2-97.3 131.2-182 0-105.9-86-191.7-192-191.7z"/></svg>
 				<span>GitHub</span>
 			</a>

--- a/docs/tags/index.html
+++ b/docs/tags/index.html
@@ -30,7 +30,7 @@
 					<img class="logo__img" src="/images/logo_400x400.jpg">
 				</div><div class="logo__item logo__text">
 					<div class="logo__title">RSE-Midlands</div>
-					<div class="logo__tagline">A community of Research Software Engineers (RSEs) within the Midlands in England.</div>
+					<div class="logo__tagline">A community of Research Software Engineers (RSEs) within the Midlands of England.</div>
 				</div>
 		</a>
 	</div>
@@ -76,13 +76,22 @@
 	<h4 class="widget-social__title widget__title">Social</h4>
 	<div class="widget-social__content widget__content">
 		<div class="widget-social__item widget__item">
-			<a class="widget-social__link widget__link btn" title="Twitter" rel="noopener noreferrer" href="https://twitter.com/RSE_Midlands" target="_blank">
+			<a class="widget-social__link widget__link btn" title="Twitter" rel="noopener noreferrer"
+				href="https://twitter.com/RSE_Midlands" target="_blank">
 				<svg class="widget-social__link-icon icon icon-twitter" width="24" height="24" viewBox="0 0 384 312"><path d="m384 36.9c-14.1 6.3-29.3 10.5-45.2 12.4 16.3-9.7 28.8-25.2 34.6-43.6-15.2 9-32.1 15.6-50 19.1-14.4-15.2-34.9-24.8-57.5-24.8-43.5 0-78.8 35.3-78.8 78.8 0 6.2.7 12.2 2 17.9-65.5-3.3-123.5-34.6-162.4-82.3-6.7 11.6-10.6 25.2-10.6 39.6 0 27.3 13.9 51.4 35 65.6-12.9-.4-25.1-4-35.7-9.9v1c0 38.2 27.2 70 63.2 77.2-6.6 1.8-13.6 2.8-20.8 2.8-5.1 0-10-.5-14.8-1.4 10 31.3 39.1 54.1 73.6 54.7-27 21.1-60.9 33.7-97.8 33.7-6.4 0-12.6-.4-18.8-1.1 34.9 22.4 76.3 35.4 120.8 35.4 144.9 0 224.1-120 224.1-224.1 0-3.4-.1-6.8-.2-10.2 15.4-11.1 28.7-25 39.3-40.8z"/></svg>
 				<span>Twitter</span>
 			</a>
 		</div>
 		<div class="widget-social__item widget__item">
-			<a class="widget-social__link widget__link btn" title="GitHub" rel="noopener noreferrer" href="https://github.com/RSE-Midlands" target="_blank">
+			<a class="widget-social__link widget__link btn" title="LinkedIn" rel="noopener noreferrer"
+				href="https://linkedin.com/groups/12657864" target="_blank">
+				<svg class="widget-social__link-icon icon icon-linkedin" width="24" height="24" viewBox="0 0 352 352"><path d="M0,40v272c0,21.9,18.1,40,40,40h272c21.9,0,40-18.1,40-40V40c0-21.9-18.1-40-40-40H40C18.1,0,0,18.1,0,40z M312,32 c4.6,0,8,3.4,8,8v272c0,4.6-3.4,8-8,8H40c-4.6,0-8-3.4-8-8V40c0-4.6,3.4-8,8-8H312z M59.5,87c0,15.2,12.3,27.5,27.5,27.5 c15.2,0,27.5-12.3,27.5-27.5c0-15.2-12.3-27.5-27.5-27.5C71.8,59.5,59.5,71.8,59.5,87z M187,157h-1v-21h-45v152h47v-75 c0-19.8,3.9-39,28.5-39c24.2,0,24.5,22.4,24.5,40v74h47v-83.5c0-40.9-8.7-72-56.5-72C208.5,132.5,193.3,145.1,187,157z M64,288h47.5 V136H64V288z"/></svg>
+				<span>LinkedIn</span>
+			</a>
+		</div>
+		<div class="widget-social__item widget__item">
+			<a class="widget-social__link widget__link btn" title="GitHub" rel="noopener noreferrer"
+				href="https://github.com/RSE-Midlands" target="_blank">
 				<svg class="widget-social__link-icon icon icon-github" width="24" height="24" viewBox="0 0 384 374"><path d="m192 0c-106.1 0-192 85.8-192 191.7 0 84.7 55 156.6 131.3 181.9 9.6 1.8 13.1-4.2 13.1-9.2 0-4.6-.2-16.6-.3-32.6-53.4 11.6-64.7-25.7-64.7-25.7-8.7-22.1-21.3-28-21.3-28-17.4-11.9 1.3-11.6 1.3-11.6 19.3 1.4 29.4 19.8 29.4 19.8 17.1 29.3 44.9 20.8 55.9 15.9 1.7-12.4 6.7-20.8 12.2-25.6-42.6-4.8-87.5-21.3-87.5-94.8 0-20.9 7.5-38 19.8-51.4-2-4.9-8.6-24.3 1.9-50.7 0 0 16.1-5.2 52.8 19.7 15.3-4.2 31.7-6.4 48.1-6.5 16.3.1 32.7 2.2 48.1 6.5 36.7-24.8 52.8-19.7 52.8-19.7 10.5 26.4 3.9 45.9 1.9 50.7 12.3 13.4 19.7 30.5 19.7 51.4 0 73.7-44.9 89.9-87.7 94.6 6.9 5.9 13 17.6 13 35.5 0 25.6-.2 46.3-.2 52.6 0 5.1 3.5 11.1 13.2 9.2 76.2-25.5 131.2-97.3 131.2-182 0-105.9-86-191.7-192-191.7z"/></svg>
 				<span>GitHub</span>
 			</a>

--- a/themes/mainroad/layouts/partials/widgets/social.html
+++ b/themes/mainroad/layouts/partials/widgets/social.html
@@ -4,7 +4,8 @@
 	<div class="widget-social__content widget__content">
 		{{- with .Site.Params.widgets.social.facebook }}
 		<div class="widget-social__item widget__item">
-			<a class="widget-social__link widget__link btn" title="Facebook" rel="noopener noreferrer" href="https://facebook.com/{{ . }}" target="_blank">
+			<a class="widget-social__link widget__link btn" title="Facebook" rel="noopener noreferrer"
+				href="https://facebook.com/{{ . }}" target="_blank">
 				{{ partial "svg/facebook.svg" (dict "class" "widget-social__link-icon") }}
 				<span>Facebook</span>
 			</a>
@@ -12,7 +13,8 @@
 		{{- end }}
 		{{- with .Site.Params.widgets.social.twitter }}
 		<div class="widget-social__item widget__item">
-			<a class="widget-social__link widget__link btn" title="Twitter" rel="noopener noreferrer" href="https://twitter.com/{{ . }}" target="_blank">
+			<a class="widget-social__link widget__link btn" title="Twitter" rel="noopener noreferrer"
+				href="https://twitter.com/{{ . }}" target="_blank">
 				{{ partial "svg/twitter.svg" (dict "class" "widget-social__link-icon") }}
 				<span>Twitter</span>
 			</a>
@@ -20,7 +22,8 @@
 		{{- end }}
 		{{- with .Site.Params.widgets.social.instagram }}
 		<div class="widget-social__item widget__item">
-			<a class="widget-social__link widget__link btn" title="Instagram" rel="noopener noreferrer" href="https://www.instagram.com/{{ . }}" target="_blank">
+			<a class="widget-social__link widget__link btn" title="Instagram" rel="noopener noreferrer"
+				href="https://www.instagram.com/{{ . }}" target="_blank">
 				{{ partial "svg/instagram.svg" (dict "class" "widget-social__link-icon") }}
 				<span>Instagram</span>
 			</a>
@@ -28,7 +31,8 @@
 		{{- end }}
 		{{- with .Site.Params.widgets.social.linkedin }}
 		<div class="widget-social__item widget__item">
-			<a class="widget-social__link widget__link btn" title="LinkedIn" rel="noopener noreferrer" href="https://linkedin.com/in/{{ . }}" target="_blank">
+			<a class="widget-social__link widget__link btn" title="LinkedIn" rel="noopener noreferrer"
+				href="https://linkedin.com/{{ . }}" target="_blank">
 				{{ partial "svg/linkedin.svg" (dict "class" "widget-social__link-icon") }}
 				<span>LinkedIn</span>
 			</a>
@@ -36,7 +40,8 @@
 		{{- end }}
 		{{- with .Site.Params.widgets.social.telegram }}
 		<div class="widget-social__item widget__item">
-			<a class="widget-social__link widget__link btn" title="Telegram" rel="noopener noreferrer" href="https://t.me/{{ . }}" target="_blank">
+			<a class="widget-social__link widget__link btn" title="Telegram" rel="noopener noreferrer"
+				href="https://t.me/{{ . }}" target="_blank">
 				{{ partial "svg/telegram.svg" (dict "class" "widget-social__link-icon") }}
 				<span>Telegram</span>
 			</a>
@@ -44,7 +49,8 @@
 		{{- end }}
 		{{- with .Site.Params.widgets.social.github }}
 		<div class="widget-social__item widget__item">
-			<a class="widget-social__link widget__link btn" title="GitHub" rel="noopener noreferrer" href="https://github.com/{{ . }}" target="_blank">
+			<a class="widget-social__link widget__link btn" title="GitHub" rel="noopener noreferrer"
+				href="https://github.com/{{ . }}" target="_blank">
 				{{ partial "svg/github.svg" (dict "class" "widget-social__link-icon") }}
 				<span>GitHub</span>
 			</a>
@@ -52,7 +58,8 @@
 		{{- end }}
 		{{- with .Site.Params.widgets.social.gitlab }}
 		<div class="widget-social__item widget__item">
-			<a class="widget-social__link widget__link btn" title="GitLab" rel="noopener noreferrer" href="https://gitlab.com/{{ . }}" target="_blank">
+			<a class="widget-social__link widget__link btn" title="GitLab" rel="noopener noreferrer"
+				href="https://gitlab.com/{{ . }}" target="_blank">
 				{{ partial "svg/gitlab.svg" (dict "class" "widget-social__link-icon") }}
 				<span>GitLab</span>
 			</a>
@@ -60,7 +67,8 @@
 		{{- end }}
 		{{- with .Site.Params.widgets.social.bitbucket }}
 		<div class="widget-social__item widget__item">
-			<a class="widget-social__link widget__link btn" title="Bitbucket" rel="noopener noreferrer" href="https://bitbucket.org/{{ . }}" target="_blank">
+			<a class="widget-social__link widget__link btn" title="Bitbucket" rel="noopener noreferrer"
+				href="https://bitbucket.org/{{ . }}" target="_blank">
 				{{ partial "svg/bitbucket.svg" (dict "class" "widget-social__link-icon") }}
 				<span>Bitbucket</span>
 			</a>
@@ -77,9 +85,10 @@
 
 		{{ range .Site.Params.widgets.social.custom }}
 		<div class="widget-social__item widget__item">
-			<a class="widget-social__link widget__link btn" title="{{ .title }}" rel="noopener noreferrer" href="{{ .url }}" target="_blank">
+			<a class="widget-social__link widget__link btn" title="{{ .title }}" rel="noopener noreferrer"
+				href="{{ .url }}" target="_blank">
 				{{- if .icon }}
-					{{ partial .icon (dict "class" "widget-social__link-icon") }}
+				{{ partial .icon (dict "class" "widget-social__link-icon") }}
 				{{- end }}
 				<span>{{ .title }}</span>
 			</a>


### PR DESCRIPTION
The link for the new LinkedIn group is on the front page and the events page is now News.