### PR TITLE
2025 event page updates

### DIFF
--- a/content/docs/event-7th-april-2025.md
+++ b/content/docs/event-7th-april-2025.md
@@ -45,7 +45,11 @@ for further details.
 
 ## Lightning Talks
 
-We are currently seeking **expressions of interest** from anybody who would like to deliver a lightning talk during the day. For guidance, talks should generally be:
+Part of the day has been set aside for lightning talks from the community, and we are very keen to hear from **you!**
+If you are interested in delivering a lightning talk, please provide a brief outline of your idea when asked during the
+registration process.
+
+For guidance, talks should generally be:
 
 - A maximum of ten minutes in length
 - No more than five slides
@@ -54,4 +58,4 @@ We are particularly interested in hearing about any **practical tips, tricks, an
 
 **Submissions from members of underrepresented communities are strongly encouraged.**
 
-If you are interested in delivering a lightning talk or have any questions about RSE Midlands 2025, please contact [James Tyrrell](mailto:j.m.tyrrell@bham.ac.uk).
+If you would like to discuss your ideas further before registering, please contact [James Tyrrell](mailto:j.m.tyrrell@bham.ac.uk).

--- a/content/docs/event-7th-april-2025.md
+++ b/content/docs/event-7th-april-2025.md
@@ -13,7 +13,7 @@ RSE Midlands 2025 will take place on Monday 7th April 2025 at
 hosted by the University of Birmingham's
 [Advanced Research Computing team](https://www.birmingham.ac.uk/research/arc/team). 
 
-### Agenda
+## Agenda
 
 Below is the agenda for the day. Please note that this is **provisional** and may change closer to the event.
 
@@ -33,7 +33,7 @@ Below is the agenda for the day. Please note that this is **provisional** and ma
 | 16:00 | **Sponsor talks**                                                        |
 | 17:00 | End                                                                      |
 
-### Lightning Talks
+## Lightning Talks
 
 We are currently seeking **expressions of interest** from anybody who would like to deliver a lightning talk during the day. For guidance, talks should generally be:
 

--- a/content/docs/event-7th-april-2025.md
+++ b/content/docs/event-7th-april-2025.md
@@ -66,7 +66,8 @@ If you would like to discuss your ideas further before registering, please conta
 need about our venue, including a virtual building tour. We have booked the Assembly Room for RSE Midlands 2025 and will
 also be making use of the Shared Catering Lounge during refreshment breaks.
 
-Please pay particular attention to the following if you plan on travelling by car:
+Please pay particular attention to the following if you plan on travelling by car
+(copied verbatim from the link above):
 
 > **Travelling by car**
 >

--- a/content/docs/event-7th-april-2025.md
+++ b/content/docs/event-7th-april-2025.md
@@ -33,6 +33,16 @@ Below is the agenda for the day. Please note that this is **provisional** and ma
 | 16:00 | **Sponsor talks**                                                        |
 | 17:00 | End                                                                      |
 
+## Registration
+
+We’d love to see you at the event - registration is free. Book at [https://pretix.eu/rsemidlands/2025/](https://pretix.eu/rsemidlands/2025/). 
+
+The registration process includes a series of questions designed to ensure that we are able to fully consider any
+potential barriers to your attendance (e.g. accessibility, dietary, financial, etc.).
+Of particular note, [the Society of Research Software Engineering](https://society-rse.org) has generously offered
+financial support with any travel, childcare, or similar expenses. Please see our [FAQ](https://pretix.eu/rsemidlands/2025/page/faq/)
+for further details.
+
 ## Lightning Talks
 
 We are currently seeking **expressions of interest** from anybody who would like to deliver a lightning talk during the day. For guidance, talks should generally be:

--- a/content/docs/event-7th-april-2025.md
+++ b/content/docs/event-7th-april-2025.md
@@ -59,3 +59,23 @@ We are particularly interested in hearing about any **practical tips, tricks, an
 **Submissions from members of underrepresented communities are strongly encouraged.**
 
 If you would like to discuss your ideas further before registering, please contact [James Tyrrell](mailto:j.m.tyrrell@bham.ac.uk).
+
+## Venue and Travel
+
+[The Exchange website](https://conferences.bham.ac.uk/venues/the-exchange/) should contain all the information you'll
+need about our venue, including a virtual building tour. We have booked the Assembly Room for RSE Midlands 2025 and will
+also be making use of the Shared Catering Lounge during refreshment breaks.
+
+Please pay particular attention to the following if you plan on travelling by car:
+
+> **Travelling by car**
+>
+> Centenary Square cannot be accessed directly by car. Therefore, we recommend putting the postcode of your chosen car park into your satnav, rather than The Exchange’s postcode.
+>
+> The Exchange lies within Birmingham’s Clean Air Zone. You can find out if you need to pay for your vehicle via the GOV.UK website, as well as pay the daily fee (if eligible) after or before your journey.
+>
+> **Parking**
+>
+> There is no on-site parking at the venue, however, you’ll find plenty of pay-and-display parking nearby. The nearest multi-storey car parks are Town Hall and Navigation Street, just a 5-minute walk away (0.3 miles). Street parking is also available at Bridge Street, just 5 minutes away.
+>
+> The nearest car park to The Exchange with designated Blue Badge parking bays is Cambridge Street. From here, the venue is just 192 yards away. A good alternative is Paradise Circus multi-storey car park (243 yards away).

--- a/content/docs/event-7th-april-2025.md
+++ b/content/docs/event-7th-april-2025.md
@@ -27,6 +27,10 @@ for further details.
 
 Below is the agenda for the day. Please note that this is **provisional** and may change closer to the event.
 
+Registration and refreshments will be available from 09:00 and are an **optional** opportunity to catch up with
+colleagues before the day begins in earnest. Please aim to arrive in good time for the introductory talks at 10:00
+(allowing some time for us to address any questions you might have about the day).
+
 | Time  | Activity                                                                 |
 | :---- | :----------------------------------------------------------------------- |
 | 09:00 | Registration and refreshments                                            |

--- a/content/docs/event-7th-april-2025.md
+++ b/content/docs/event-7th-april-2025.md
@@ -79,3 +79,10 @@ Please pay particular attention to the following if you plan on travelling by ca
 > There is no on-site parking at the venue, however, you’ll find plenty of pay-and-display parking nearby. The nearest multi-storey car parks are Town Hall and Navigation Street, just a 5-minute walk away (0.3 miles). Street parking is also available at Bridge Street, just 5 minutes away.
 >
 > The nearest car park to The Exchange with designated Blue Badge parking bays is Cambridge Street. From here, the venue is just 192 yards away. A good alternative is Paradise Circus multi-storey car park (243 yards away).
+
+## Organising Committee
+
+Our organising committee for this year are [James Tyrrell](https://www.birmingham.ac.uk/research/arc/rsg/staff/james-tyrrell),
+[Gavin Yearwood](https://www.birmingham.ac.uk/research/arc/rsg/staff/gavin-yearwood),
+[Matthew Barton](https://www.birmingham.ac.uk/research/arc/rsg/staff/matthew-barton),
+and [Adrian Garcia](https://www.birmingham.ac.uk/research/arc/rsg/staff/adrian-garcia).

--- a/content/docs/event-7th-april-2025.md
+++ b/content/docs/event-7th-april-2025.md
@@ -86,3 +86,12 @@ Our organising committee for this year are [James Tyrrell](https://www.birmingha
 [Gavin Yearwood](https://www.birmingham.ac.uk/research/arc/rsg/staff/gavin-yearwood),
 [Matthew Barton](https://www.birmingham.ac.uk/research/arc/rsg/staff/matthew-barton),
 and [Adrian Garcia](https://www.birmingham.ac.uk/research/arc/rsg/staff/adrian-garcia).
+
+## Sponsors
+
+Our sponsors for this year are:
+
+- [Lenovo](https://www.lenovo.com/)
+- [Intel](https://www.intel.com/)
+- [The Society of Research Software Engineering](https://society-rse.org/)
+- [Advanced Research Computing (University of Birmingham)](https://www.birmingham.ac.uk/research/arc)

--- a/content/docs/event-7th-april-2025.md
+++ b/content/docs/event-7th-april-2025.md
@@ -13,6 +13,16 @@ RSE Midlands 2025 will take place on Monday 7th April 2025 at
 hosted by the University of Birmingham's
 [Advanced Research Computing team](https://www.birmingham.ac.uk/research/arc/team). 
 
+## Registration
+
+We’d love to see you at the event - registration is free. Book at [https://pretix.eu/rsemidlands/2025/](https://pretix.eu/rsemidlands/2025/). 
+
+The registration process includes a series of questions designed to ensure that we are able to fully consider any
+potential barriers to your attendance (e.g. accessibility, dietary, financial, etc.).
+Of particular note, [the Society of Research Software Engineering](https://society-rse.org) has generously offered
+financial support with any travel, childcare, or similar expenses. Please see our [FAQ](https://pretix.eu/rsemidlands/2025/page/faq/)
+for further details.
+
 ## Agenda
 
 Below is the agenda for the day. Please note that this is **provisional** and may change closer to the event.
@@ -32,16 +42,6 @@ Below is the agenda for the day. Please note that this is **provisional** and ma
 | 15:30 | Refreshments (PM)                                                        |
 | 16:00 | **Sponsor talks**                                                        |
 | 17:00 | End                                                                      |
-
-## Registration
-
-We’d love to see you at the event - registration is free. Book at [https://pretix.eu/rsemidlands/2025/](https://pretix.eu/rsemidlands/2025/). 
-
-The registration process includes a series of questions designed to ensure that we are able to fully consider any
-potential barriers to your attendance (e.g. accessibility, dietary, financial, etc.).
-Of particular note, [the Society of Research Software Engineering](https://society-rse.org) has generously offered
-financial support with any travel, childcare, or similar expenses. Please see our [FAQ](https://pretix.eu/rsemidlands/2025/page/faq/)
-for further details.
 
 ## Lightning Talks
 


### PR DESCRIPTION
Added a bunch; might be easiest to look commit-by-commit.

Please check in particular that you are happy with the "Organising Committee" and "Sponsors" sections! Logos would be better for sponsors, but I think we're still waiting on the Intel one.