### PR TITLE
add link to event page to landing page

### DIFF
--- a/themes/mainroad/layouts/index.html
+++ b/themes/mainroad/layouts/index.html
@@ -11,11 +11,7 @@
 			RSE Midlands 2025 will take place on Monday 7th April 2025 at <a href="https://conferences.bham.ac.uk/venues/the-exchange">The Exchange, 3 Centenary Square, B1 2DR</a>, hosted by the University of Birmingham's <a href="https://www.birmingham.ac.uk/research/arc/team">Advanced Research Computing team</a>.
 		</p>
 		<p>
-			We are seeking <b>expressions of interest</b> from anyone who would like to deliver a lightning talk during the event. Please see our "<a href="https://ukrse.slack.com/archives/C02333HNA64">#midlands</a>" channel in the
-			<a href="https://join.slack.com/t/ukrse/signup">RSE Society's slack workspace</a> for full details.
-		</p>
-		<p>
-			Further information on how to secure tickets will follow in due course.
+			More details, including information on how to register for the event, are available <a href="https://rse-midlands.github.io/docs/event-7th-april-2025/">here</a>.
 		</p>
 
 		<h2>RSE Midlands 2024</h2>


### PR DESCRIPTION
and remove sections on lightning talks and "tickets to follow soon..." (this info is now covered in the event page)