### PR TITLE
Expand content on event page

### DIFF
--- a/content/docs/event-20th-april-2026.md
+++ b/content/docs/event-20th-april-2026.md
@@ -8,47 +8,61 @@ pager: false
 weight: 1
 ---
 
-RSE Midlands 2026 will take place on 20th April 2026 at
+RSE Midlands 2026 will take place on 20th April 2026 at the 
 [Advanced Manufacturing Building, University of Nottingham, NG7 2GX](https://www.nottingham.ac.uk/mcm/howtofindus.aspx).
 
 ## Tickets
 
-Tickets out now you can get your tickets [here](https://pretix.eu/rsemidlands/2026/)
+Registration for the 2026 conference is now open. Please register in advance using the link below:<br>
+ [https://pretix.eu/rsemidlands/2026/](https://pretix.eu/rsemidlands/2026/)
+
 
 ## Call for talks
 
-If you would like to give a talk please can you email Kwabena Amponsah [kwabena.amponsah1@nottingham.ac.uk](mailto:kwabena.amponsah1@nottingham.ac.uk) with the details of your request.
-
 ### 30 - 15 minute talks
 
-There are two, 30-minute or four 15-minute slots available to give a talk.
-If you have a project you have worked on, a useful tool that you wish to share or even a talk about being an RSE from your institution, then please get in contact with us.
+There are still a few slots available for 15-minute or 30-minute talks. If you have a project you have worked on, a 
+useful tool to share, or would like to speak about your experience as an RSE at your institution, we would be glad to 
+hear from you. Please get in touch with us or indicate your interest on the [registration form](https://pretix.eu/rsemidlands/2026/).
 
 ### Lightning talks
 
-We have slots for shorter 5 to 10-minute lightning talks.
-This is an opportunity for those in the RSE Midlands space to give a talk that can either be on their work or community projects that they are involved with:
-This can be to inform or seek assistance.
+We have slots available for short 5 to 10-minute lightning talks. This is a great opportunity to showcase your work or 
+highlight community projects you are involved in. Talks can be used to share insights, inform others, or seek feedback 
+and collaboration. Please get in touch with us or indicate your interest on the [registration form](https://pretix.eu/rsemidlands/2026/).
+
+
+## Financial support
+
+Thanks to funding from the Society of Research Software Engineering's 
+[Events and Initiatives Grant](https://society-rse.org/policy-for-socrse-events-and-initiatives-grant/),
+we may be able to offer some support to help cover costs such as travel or childcare where these would otherwise be
+a barrier to attendance. If you would like to request support , please indicate this on the 
+[registration form](https://pretix.eu/rsemidlands/2026/) or contact 
+Kwabena Amponsah ([kwabena.amponsah1@nottingham.ac.uk](mailto:kwabena.amponsah1@nottingham.ac.uk))
+at your earliest convenience to discuss how we may be able to assist. Please note that we cannot guarantee 
+reimbursement of any costs unless this has been agreed with us in advance.
+
 
 ## Agenda
 
 | Time  | Activity                                                                                                     |
 | ----- | -------------------------------------------------------------------------------------------------------------|
 | 09:00 | Registration                                                                                                 |
-| 10:00 | Session 1 - Academic                                                                                         |
+| 10:00 | **Session 1**                                                                                                |
 |       | Open-source, but paying the bills: PsychoPy's story - Jonathan Peirce (University of Nottingham)             |
 |       | RSE for data-driven AI research - Grazziela Figueredo (University of Nottingham)                             |
 | 11:00 | Refreshments                                                                                                 |
-| 11:30 | Session 2 - EDI & Lightning talks                                                                            |
+| 11:30 | **Session 2**                                                                                                |
 |       | EDI - Jeremy Cohen (Imperial College London), Ella Kaye (University of Birmingham)                           |
 |       | Lightning talks                                                                                              |
 | 13:00 | Lunch                                                                                                        |
-| 14:00 | Session 3 - Practical                                                                                        |
+| 14:00 | **Session 3**                                                                                                |
 |       | VisP2: The Data Visualization process for software development - Robert Laramee (University of Nottingham)   |
 |       | An introduction to Apptainer: Portable and Reproducible Workflows on HPC - Bradley Davy (OCF sponsored talk) |
 |       | The reluctant developer's guide to the software development universe - Mike Croucher (Mathworks)             |
 | 15:30 | Refreshments                                                                                                 |
-| 16:00 | Session 4 - RSESoc & Panel                                                                                   |
+| 16:00 | **Session 4**                                                                                                |
 |       | RSE Society Sponsored talk - James Tyrrell (University of Birmingham)                                        |
 |       | Panel Session: Raising the visibility of RSE groups within Universities (details below)                      |
 | 16:55 | Closing Remarks                                                                                              |
@@ -57,9 +71,95 @@ This can be to inform or seek assistance.
 
 **Panel Coordinator:** Louise Brown
 
-**Panel Chair:** Armando Mendez
+**Panel Chair:** Armando Mendez Villalon
 
 **Panel Members:**
 * Adrian Garcia, University of Birmingham
 * Andrew Hadfield, University of Nottingham
 * Mike Croucher, Mathworks
+
+
+## Venue and Travel
+
+The venue for RSE Midlands 2026 will be:
+
+> **Advanced Manufacturing Building**<br>
+> Jubilee Campus, University of Nottingham<br>
+> Derby Rd, Nottingham<br>
+> NG7 2GX
+
+### Travelling by train
+
+The nearest station is **Nottingham Railway Station**.<br>
+From the station, continue to Jubilee Campus by tram or bus.
+
+#### By tram (recommended)
+
+* From Nottingham Railway Station / city centre, take the tram towards **Toton Lane**.
+* Alight at **Queen's Medical Centre** tram stop
+* The venue is a 10-minute walk from the stop.
+
+Tickets must be purchased before boarding.<br>
+https://www.thetram.net/network-information
+
+#### By bus
+
+* Take a bus (or connecting buses) to **Hillside bus stop (Stop LE12, Lenton)**
+* The venue is a short walk from the stop
+
+Bus services run regularly from Nottingham city centre and the railway station.<br>
+Visitors are advised to check routes and timetables in advance.
+
+For further travel details, please visit:<br>
+https://www.nottingham.ac.uk/mcm/howtofindus.aspx
+
+
+### Travelling by car
+
+#### Parking
+
+Visitor parking is available on **Jubilee Campus** in designated areas.
+
+* Visitors are encouraged to use the **RingGo app**.
+* Pay-and-display machines are also available in some areas.
+* Typical weekday tariffs: **£12** for all-day parking.
+
+For parking maps and full details, please visit:<br>
+https://www.nottingham.ac.uk/estates/security/carparking/home.aspx
+
+
+#### Park and ride
+
+Park and ride options are also available from several locations on the outskirts of Nottingham.<br>
+https://www.thetram.net/park-and-ride
+
+#### Electric Vehicles
+
+EV charging points are available on Jubilee Campus. More information can be found here:<br>
+https://www.nottingham.ac.uk/sustainability/transport/electricvehicles.aspx
+
+
+## Organising Committee
+
+Our organising committee for this year are 
+[Andrew Warry](https://orcid.org/0000-0002-7647-9164), 
+[Armando Mendez Villalon](https://orcid.org/0000-0001-5948-7560), 
+[Gavin Yearwood](https://www.birmingham.ac.uk/research/arc/rsg/staff/gavin-yearwood), 
+[Godwin Yeboah](https://warwick.ac.uk/fac/arts/research/digitalhumanities/team/contactus/), 
+[James Tyrrell](https://www.birmingham.ac.uk/research/arc/rsg/staff/james-tyrrell), 
+[Kwabena Amponsah](https://orcid.org/0000-0002-7506-9040) and 
+[Louise Brown](https://www.birmingham.ac.uk/research/arc/rsg/staff/louise-brown).
+
+
+## Sponsors
+
+Our sponsors for this year are:
+
+* [OCF](https://ocf.co.uk)
+* [The Society of Research Software Engineering](https://society-rse.org/)
+
+
+## Contact
+
+You can find us on our slack channel [#midlands](https://ukrse.slack.com/archives/C02333HNA64) in the [RSE Society's slack workspace](https://join.slack.com/t/ukrse/signup) and [on Mastodon](https://mastodon.social/@RSE_Midlands)!
+


### PR DESCRIPTION
**Changes**

-  Add travel info
-  Add bursary info
- Add sponsors
- Add organising committee
- Add social media and slack
- Make calls for talks slightly more inclusive